### PR TITLE
Workaround for the problem with uvm_sequncer

### DIFF
--- a/sv/modified/pipe_sequencer.sv
+++ b/sv/modified/pipe_sequencer.sv
@@ -17,7 +17,11 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+`ifndef VERILATOR
 class pipe_sequencer extends uvm_sequencer #(data_packet);
+`else
+class pipe_sequencer extends uvm_sequencer #(data_packet, data_packet);
+`endif
 
    int max_count = 100;
 

--- a/sv/pipe_sequencer.sv
+++ b/sv/pipe_sequencer.sv
@@ -17,7 +17,11 @@
 //   permissions and limitations under the License.
 //----------------------------------------------------------------------
 
+`ifndef VERILATOR
 class pipe_sequencer extends uvm_sequencer #(data_packet);
+`else
+class pipe_sequencer extends uvm_sequencer #(data_packet, data_packet);
+`endif
 
    //`uvm_sequencer_utils(pipe_sequencer)
    `uvm_object_utils(pipe_sequencer)


### PR DESCRIPTION
It adds a workaround for the problem with `uvm_sequncer`: https://github.com/verilator/verilator/issues/4497. The 2nd parameter is optional and is equal to the 1st by default. Verilator doesn't handle it correctly, so always 2 parameters should be provided.