### PR TITLE
Change UVM branch and disable DPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ First, install the latest version of Verilator.  See https://verilator.org/guide
 Second, create a shell environment variable `UVM_HOME` and clone the version of the UVM library from ChipsAlliance there. 
 ```
 $ export UVM_HOME="/location/of/UVM/lib"
-$ git clone git@github.com:chipsalliance/uvm-verilator.git $UVM_HOME
+$ git clone git@github.com:antmicro/uvm-verilator.git -b current-patches $UVM_HOME
 ```
 
 The (somewhat brain-dead) script will get you started:

--- a/scripts/run_verilator.sh
+++ b/scripts/run_verilator.sh
@@ -120,6 +120,7 @@ DISABLED_WARNINGS="-Wno-DECLFILENAME \
      $DISABLED_WARNINGS \
      +define+UVM_REPORT_DISABLE_FILE_LINE \
      +define+SVA_ON \
+     +define+UVM_NO_DPI \
      +incdir+$UVM_HOME \
      +incdir+../rtl \
      +incdir+../sv \


### PR DESCRIPTION
It disables DPI, because it is currently unsupported. It also changes UVM branch to the one that contains more workarounds for issues. The only commit that may affect functionality (assuming that DPI is disabled) is https://github.com/antmicro/uvm-verilator/commit/2e667ac506c12e91d81bde62fe2c08d992731bd4. We work on fixing this problem.