### PR TITLE
Add container setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+*.swp
+**/obj_dir
+**/logs
+sim/deprecated
+.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+.cache

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 Yusef Karim
+# SPDX-License-Identifier: Apache-2.0
+
+# Verilator release tag (mirrors the version called out in the top-level README).
+# Override with --build-arg VERILATOR_VERSION=<tag>, e.g. v5.048.
+ARG VERILATOR_VERSION=v5.050
+FROM verilator/verilator:${VERILATOR_VERSION}
+
+# Accellera UVM library version. The archive's top-level directory matches this
+# string, so extracting into /opt/accellera/ yields
+# /opt/accellera/<UVM_VERSION>/src, which UVM_HOME below points at.
+ARG UVM_VERSION=1800.2-2017-1.0
+ADD https://www.accellera.org/images/downloads/standards/uvm/Accellera-${UVM_VERSION}.tar.gz /tmp/uvm.tar.gz
+RUN mkdir -p /opt/accellera \
+ && tar xzf /tmp/uvm.tar.gz -C /opt/accellera/ \
+ && rm /tmp/uvm.tar.gz
+# Exposed so sim/Makefile picks up the path at run time without a command-line override.
+ENV UVM_HOME=/opt/accellera/${UVM_VERSION}/src
+
+# Install z3 SAT solver.
+# Verilator shells out to z3 when evaluating SVA assertions at runtime.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends z3 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy the project sources in. For day-to-day development, it's better to bind-mount your
+# working tree over /work instead (see README) so edits don't require a rebuild.
+COPY . /work
+
+ENV HOME=/work
+WORKDIR /work/sim
+
+# Clear base image ENTRYPOINT.
+ENTRYPOINT []
+
+# `make all` cleans, builds, runs every test, and produces the coverage report.
+CMD ["make", "all"]

--- a/Containerfile
+++ b/Containerfile
@@ -19,8 +19,11 @@ ENV UVM_HOME=/opt/accellera/${UVM_VERSION}/src
 
 # Install z3 SAT solver.
 # Verilator shells out to z3 when evaluating SVA assertions at runtime.
+# Z3_VERSION is pinned to the exact package from the base image's Ubuntu noble
+# archive; override only if you retarget the base image.
+ARG Z3_VERSION=4.8.12-3.1build1
 RUN apt-get update \
- && apt-get install -y --no-install-recommends z3 \
+ && apt-get install -y --no-install-recommends z3=${Z3_VERSION} \
  && rm -rf /var/lib/apt/lists/*
 
 # Copy the project sources in. For day-to-day development, it's better to bind-mount your

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ The included `Containerfile` builds on the official `verilator/verilator` image
 (see https://hub.docker.com/r/verilator/verilator) and layers in the Accellera UVM library.
 With this, no local Verilator or UVM install is needed.
 
+> [!NOTE]
+> The commands below use `podman`, but `docker` works too with two adjustments: pass
+> `-f Containerfile` to `docker build` (docker looks for `Dockerfile` by default),
+> and drop `--userns=keep-id` from `docker run` (docker doesn't support that flag).
+
 ### Build the image
 
 From the repository root:
@@ -213,7 +218,7 @@ podman build -t verilator-uvm .
 > ```
 > Available Verilator release tags mirror the
 > [verilator/verilator](https://hub.docker.com/r/verilator/verilator/tags) image on
-> Docker Hub (e.g. `v5.048`, `v5.050`). Available UVM versions are the
+> Docker Hub (e.g. `v5.048`, `v5.050`). Available UVM versions are those
 > published by [Accellera](https://www.accellera.org/downloads/standards/uvm/).
 
 ### Get a shell inside the container
@@ -221,8 +226,6 @@ podman build -t verilator-uvm .
 ```sh
 podman run --rm -it --userns=keep-id --user "$(id -u):$(id -g)" -v "$PWD":/work verilator-uvm bash
 ```
-
-> NOTE: If using `docker`, omit the `--userns=keep-id` option.
 
 From here, you can run any make command you normally would, but now from inside the container with all the
 necessary dependencies preinstalled for you. Generated artifacts (`obj_dir`, `logs`) are written under the

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ or try something from 'Future Work' (at the end of this README).
 5. Large number of UVM_WARNING @ t=0: (violations the uvm component name constraints). Investigating.
 6. Successful execution of the `data0_test`:
 <details>
-  
+
 ```
 - V e r i l a t i o n   R e p o r t: Verilator 5.050 2026-07-01 rev v5.050
 - Verilator: Built from 14.785 MB sources in 358 modules, into 27.841 MB in 2056 C++ files needing 99.110 MB
@@ -46,7 +46,7 @@ Running data0_test...
     +UVM_TESTNAME="data0_test" \
     +verilator+coverage+file+logs/coverage/data0_test.cov \
     2>&1 | tee logs/data0_test.log
-UVM_INFO @ 0: reporter [UVM/RELNOTES] 
+UVM_INFO @ 0: reporter [UVM/RELNOTES]
   ***********       IMPORTANT RELEASE NOTES         ************
 
   This implementation of the UVM Library deviates from the 1800.2-2017
@@ -82,53 +82,53 @@ UVM_INFO @ 0: uvm_test_top [data0_test] Printing the test topology :
 -----------------------------------------------------------------------
 Name                            Type                        Size  Value
 -----------------------------------------------------------------------
-uvm_test_top                    data0_test                  -     @121 
-  env                           dut_env                     -     @166 
-    penv_in                     pipe_env                    -     @187 
-      agent                     pipe_agent                  -     @236 
-        driver                  pipe_driver                 -     @389 
-          rsp_port              uvm_analysis_port           -     @408 
-          seq_item_port         uvm_seq_item_pull_port      -     @398 
-        monitor                 pipe_monitor                -     @418 
-          item_collected_port   uvm_analysis_port           -     @444 
-        sequencer               pipe_sequencer              -     @252 
-          rsp_export            uvm_analysis_export         -     @261 
-          seq_item_export       uvm_seq_item_pull_imp       -     @379 
-          arbitration_queue     array                       0     -    
-          lock_queue            array                       0     -    
-          num_last_reqs         integral                    32    'd1  
-          num_last_rsps         integral                    32    'd1  
-    penv_out                    pipe_env                    -     @196 
-      agent                     pipe_agent                  -     @463 
-        monitor                 pipe_monitor                -     @478 
-          item_collected_port   uvm_analysis_port           -     @498 
-    pipe_cov                    pipe_coverage               -     @214 
-      analysis_imp              uvm_analysis_imp            -     @223 
-    sb                          pipe_scoreboard             -     @205 
-      input_packets_collected   uvm_tlm_analysis_fifo #(T)  -     @516 
-        analysis_export         uvm_analysis_imp            -     @565 
-        get_ap                  uvm_analysis_port           -     @555 
-        get_peek_export         uvm_get_peek_imp            -     @535 
-        put_ap                  uvm_analysis_port           -     @545 
-        put_export              uvm_put_imp                 -     @525 
-      output_packets_collected  uvm_tlm_analysis_fifo #(T)  -     @575 
-        analysis_export         uvm_analysis_imp            -     @624 
-        get_ap                  uvm_analysis_port           -     @614 
-        get_peek_export         uvm_get_peek_imp            -     @594 
-        put_ap                  uvm_analysis_port           -     @604 
-        put_export              uvm_put_imp                 -     @584 
+uvm_test_top                    data0_test                  -     @121
+  env                           dut_env                     -     @166
+    penv_in                     pipe_env                    -     @187
+      agent                     pipe_agent                  -     @236
+        driver                  pipe_driver                 -     @389
+          rsp_port              uvm_analysis_port           -     @408
+          seq_item_port         uvm_seq_item_pull_port      -     @398
+        monitor                 pipe_monitor                -     @418
+          item_collected_port   uvm_analysis_port           -     @444
+        sequencer               pipe_sequencer              -     @252
+          rsp_export            uvm_analysis_export         -     @261
+          seq_item_export       uvm_seq_item_pull_imp       -     @379
+          arbitration_queue     array                       0     -
+          lock_queue            array                       0     -
+          num_last_reqs         integral                    32    'd1
+          num_last_rsps         integral                    32    'd1
+    penv_out                    pipe_env                    -     @196
+      agent                     pipe_agent                  -     @463
+        monitor                 pipe_monitor                -     @478
+          item_collected_port   uvm_analysis_port           -     @498
+    pipe_cov                    pipe_coverage               -     @214
+      analysis_imp              uvm_analysis_imp            -     @223
+    sb                          pipe_scoreboard             -     @205
+      input_packets_collected   uvm_tlm_analysis_fifo #(T)  -     @516
+        analysis_export         uvm_analysis_imp            -     @565
+        get_ap                  uvm_analysis_port           -     @555
+        get_peek_export         uvm_get_peek_imp            -     @535
+        put_ap                  uvm_analysis_port           -     @545
+        put_export              uvm_put_imp                 -     @525
+      output_packets_collected  uvm_tlm_analysis_fifo #(T)  -     @575
+        analysis_export         uvm_analysis_imp            -     @624
+        get_ap                  uvm_analysis_port           -     @614
+        get_peek_export         uvm_get_peek_imp            -     @594
+        put_ap                  uvm_analysis_port           -     @604
+        put_export              uvm_put_imp                 -     @584
 -----------------------------------------------------------------------
 
 UVM_INFO @ 0: reporter [UVM/COMP/NAMECHECK] This implementation of the component name checks requires DPI to be enabled
 UVM_WARNING @ 0: reporter [UVM/COMP/NAME] the name "uvm_test_top" of the component "uvm_test_top" violates the uvm component name constraints
 ... deleted a rather large number of warnings similar to the above ...
 
-UVM_INFO @ 0: uvm_test_top.env.penv_in.agent.driver [pipe_driver] Resetting signals ... 
+UVM_INFO @ 0: uvm_test_top.env.penv_in.agent.driver [pipe_driver] Resetting signals ...
 UVM_INFO @ 1545: uvm_test_top.env.pipe_cov [pipe_coverage] Number of coverage packets collected = 152
 UVM_INFO @ 1545: uvm_test_top.env.pipe_cov [pipe_coverage] Current coverage  = 0.000000
 UVM_INFO @ 1545: uvm_test_top.env.penv_in.agent.monitor [pipe_monitor] REPORT: COLLECTED PACKETS = 76
 UVM_INFO @ 1545: uvm_test_top.env.penv_out.agent.monitor [pipe_monitor] REPORT: COLLECTED PACKETS = 76
-UVM_INFO @ 1545: reporter [UVM/REPORT/SERVER] 
+UVM_INFO @ 1545: reporter [UVM/REPORT/SERVER]
 --- UVM Report Summary ---
 
 ** Report counts by severity
@@ -166,7 +166,7 @@ UVM_FATAL :    0
 ## Code Coverage!
 The Makefile compiles, runs and merges all supported code coverage and produces a result simular to the following:
 <details>
-  
+
 ```
 verilator_coverage --annotate logs/annotated_src logs/coverage/*.cov
 Coverage Summary:
@@ -189,6 +189,57 @@ verilator_coverage --rank logs/coverage/*.cov > logs/coverage_ranking.txt
 ```
 $ cd sim
 $ make all
+```
+
+## Run it in a container
+
+The included `Containerfile` builds on the official `verilator/verilator` image
+(see https://hub.docker.com/r/verilator/verilator) and layers in the Accellera UVM library.
+With this, no local Verilator or UVM install is needed.
+
+### Build the image
+
+From the repository root:
+```sh
+podman build -t verilator-uvm .
+```
+
+> [!NOTE]
+> The `Containerfile` accepts `VERILATOR_VERSION` and `UVM_VERSION` build args (both
+> default to the versions pinned in this repo). To experiment with a different
+> combination, override them at build time:
+> ```sh
+> podman build --build-arg VERILATOR_VERSION=v5.048 --build-arg UVM_VERSION=1800.2-2017-1.0 -t verilator-uvm .
+> ```
+> Available Verilator release tags mirror the
+> [verilator/verilator](https://hub.docker.com/r/verilator/verilator/tags) image on
+> Docker Hub (e.g. `v5.048`, `v5.050`). Available UVM versions are the
+> published by [Accellera](https://www.accellera.org/downloads/standards/uvm/).
+
+### Get a shell inside the container
+
+```sh
+podman run --rm -it --userns=keep-id --user "$(id -u):$(id -g)" -v "$PWD":/work verilator-uvm bash
+```
+
+> NOTE: If using `docker`, omit the `--userns=keep-id` option.
+
+From here, you can run any make command you normally would, but now from inside the container with all the
+necessary dependencies preinstalled for you. Generated artifacts (`obj_dir`, `logs`) are written under the
+bind-mounted working tree, so they appear on the host just as they would for a native run.
+
+### Run everything (clean, build, run all tests, coverage report)
+
+```sh
+podman run --rm --userns=keep-id --user "$(id -u):$(id -g)" -v "$PWD":/work verilator-uvm
+```
+
+The image's default command is `make all`, run from `/work/sim`.
+
+### Run a single test
+
+```sh
+podman run --rm --userns=keep-id --user "$(id -u):$(id -g)" -v "$PWD":/work verilator-uvm make one UVM_TESTNAME=data0_test
 ```
 
 ## Future Work

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -3,6 +3,11 @@
 
 # TODO: seed management
 
+# Run recipes with bash + pipefail so `cmd | tee` surfaces cmd's exit status
+# (rather than tee's), and run_all aborts on the first failed test.
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
+
 # Variables
 BANNER     = "*******************************************************************************"
 VERILATOR  = verilator
@@ -112,7 +117,7 @@ run_all: $(OBJ_DIR)/V$(TOP_MODULE)
 	@echo "Running _all_ testcases..."
 	@echo $(BANNER)
 	@mkdir -p $(COV_DIR)
-	@for testname in $(ALL_TESTNAMES); do \
+	@set -e; for testname in $(ALL_TESTNAMES); do \
 		echo "Creating $$testname..."; \
 		./$(OBJ_DIR)/V$(TOP_MODULE) \
 			+UVM_TESTNAME="$$testname" \

--- a/sim/Makefile
+++ b/sim/Makefile
@@ -15,7 +15,8 @@ SV_SOURCES = ../sv/pipe_pkg.sv \
 
 # UVM variables
 # Accelera's UVM library fetched with `wget https://www.accellera.org/images/downloads/standards/uvm/Accellera-1800.2-2017-1.0.tar.gz`
-UVM_HOME       = /opt/accellera/1800.2-2017-1.0/src
+# Use ?= so the container image can inject UVM_HOME via its environment.
+UVM_HOME       ?= /opt/accellera/1800.2-2017-1.0/src
 UVM_PKG        = $(UVM_HOME)/uvm_pkg.sv
 UVM_TESTNAME  ?= data0_test
 ALL_TESTNAMES ?= data0_test data1_test random_test many_random_test


### PR DESCRIPTION
For https://github.com/MikeCovrado/GettingVerilatorStartedWithUVM/issues/12.

Adds a Containerfile that can be used to locally build a container image to then be launched as a self-contained container-based development environment containing both Verilator and UVM. Instructions focus on using Podman (recommended), but everything will work with Docker too (as noted in the README).

Maintaining this should be low effort, you just need to bump the `VERILATOR_VERSION` and `UVM_VERSION` default values everytime you would like to move the repo to a newer version of either respectively.

Note, this could be taken one step further. GitHub has its own built-in container registry, and it is easy to create a GitHub action to automatically build the container added in this PR (e.g., every time a push is made to `main` or everytime you make a new tag on the repo). For example, see: https://github.com/riscv-ottawa/vega-quickstart/blob/main/.github/workflows/publish-container.yml. This way people can pull and use the image built by this repo themselves (given they have an Internet connection) without having to build anything themselves. Feel free to add a new issue if that is of interest, happy to make a PR for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added container-based workflows for building, testing, and running individual simulations.
  * Added configurable Verilator and UVM versions for container setup.
  * Included the Z3 solver for runtime assertion evaluation.

* **Documentation**
  * Added container usage instructions and updated example output formatting.

* **Chores**
  * Improved build-context and local cache exclusions.
  * Enabled external configuration of the UVM installation path.
  * Improved test command reliability by stopping on pipeline or test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->